### PR TITLE
Add prototype compilation function

### DIFF
--- a/Deferred.js
+++ b/Deferred.js
@@ -1,0 +1,406 @@
+/*******************************************************************************
+ * @license
+ * Copyright (c) 2012 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials are made 
+ * available under the terms of the Eclipse Public License v1.0 
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution 
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html). 
+ * 
+ * Contributors: IBM Corporation - initial API and implementation
+ ******************************************************************************/
+/*eslint-env browser, amd, node*/
+(function(root, factory) { // UMD
+    if (typeof define === "function" && define.amd) { //$NON-NLS-0$
+        define(factory);
+    } else if (typeof exports === "object") { //$NON-NLS-0$
+        module.exports = factory();
+    } else {
+        root.orion = root.orion || {};
+        root.orion.Deferred = factory();
+    }
+}(this, function() {
+    var queue = [],
+        running = false;
+
+    function run() {
+        var fn;
+        while ((fn = queue.shift())) {
+            fn();
+        }
+        running = false;
+    }
+
+	var runAsync = (function() {
+		if (typeof process !== "undefined" && typeof process.nextTick === "function") {
+			var nextTick = process.nextTick;
+    		return function() {
+    			nextTick(run);
+    		};
+		} else if (typeof MutationObserver === "function") {
+			var div = document.createElement("div");
+			var observer = new MutationObserver(run);
+			observer.observe(div, {
+            	attributes: true
+        	});
+        	return function() {
+        		div.setAttribute("class", "_tick");
+        	};
+		}
+		return function() {
+			setTimeout(run, 0);
+		};
+	})();
+
+    function enqueue(fn) {
+        queue.push(fn);
+        if (!running) {
+            running = true;
+            runAsync();
+        }
+    }
+
+    function noReturn(fn) {
+        return function(result) {
+            fn(result);
+        };
+    }
+    
+    function settleDeferred(fn, result, deferred) {
+    	try {
+    		var listenerResult = fn(result);
+    		var listenerThen = listenerResult && (typeof listenerResult === "object" || typeof listenerResult === "function") && listenerResult.then;
+    		if (typeof listenerThen === "function") {
+    			if (listenerResult === deferred.promise) {
+    				deferred.reject(new TypeError());
+    			} else {
+    				var listenerResultCancel = listenerResult.cancel;
+    				if (typeof listenerResultCancel === "function") {
+    					deferred._parentCancel = listenerResultCancel.bind(listenerResult);
+    				} else {
+    					delete deferred._parentCancel;
+    				}
+    				listenerThen.call(listenerResult, noReturn(deferred.resolve), noReturn(deferred.reject), noReturn(deferred.progress));
+    			}
+    		} else {
+    			deferred.resolve(listenerResult);
+    		}
+    	} catch (e) {
+    		deferred.reject(e);
+    	}
+    }
+
+
+    /**
+     * @name orion.Promise
+     * @class Interface representing an eventual value.
+     * @description Promise is an interface that represents an eventual value returned from the single completion of an operation.
+     *
+     * <p>For a concrete class that implements Promise and provides additional API, see {@link orion.Deferred}.</p>
+     * @see orion.Deferred
+     * @see orion.Deferred#promise
+     */
+    /**
+     * @name then
+     * @function
+     * @memberOf orion.Promise.prototype
+     * @description Adds handlers to be called on fulfillment or progress of this promise.
+     * @param {Function} [onResolve] Called when this promise is resolved.
+     * @param {Function} [onReject] Called when this promise is rejected.
+     * @param {Function} [onProgress] May be called to report progress events on this promise.
+     * @returns {orion.Promise} A new promise that is fulfilled when the given <code>onResolve</code> or <code>onReject</code>
+     * callback is finished. The callback's return value gives the fulfillment value of the returned promise.
+     */
+    /**
+     * Cancels this promise.
+     * @name cancel
+     * @function
+     * @memberOf orion.Promise.prototype
+     * @param {Object} reason The reason for canceling this promise.
+     * @param {Boolean} [strict]
+     */
+
+    /**
+     * @name orion.Deferred
+     * @borrows orion.Promise#then as #then
+     * @borrows orion.Promise#cancel as #cancel
+     * @class Provides abstraction over asynchronous operations.
+     * @description Deferred provides abstraction over asynchronous operations.
+     *
+     * <p>Because Deferred implements the {@link orion.Promise} interface, a Deferred may be used anywhere a Promise is called for.
+     * However, in most such cases it is recommended to use the Deferred's {@link #promise} field instead, which exposes a 
+     * simplified, minimally <a href="https://github.com/promises-aplus/promises-spec">Promises/A+</a>-compliant interface to callers.</p>
+     */
+    function Deferred() {
+        var result, state, listeners = [],
+            _this = this;
+
+        function notify() {
+            var listener;
+            while ((listener = listeners.shift())) {
+                var deferred = listener.deferred;
+                var methodName = state === "fulfilled" ? "resolve" : "reject"; //$NON-NLS-0$ //$NON-NLS-1$ //$NON-NLS-2$
+                var fn = listener[methodName];
+                if (typeof fn === "function") { //$NON-NLS-0$
+                	settleDeferred(fn, result, deferred);
+                } else {
+                    deferred[methodName](result);
+                }
+            }
+        }
+
+        function _reject(error) {
+            delete _this._parentCancel;
+            state = "rejected";
+            result = error;
+            if (listeners.length) {
+                enqueue(notify);
+            }
+        }
+
+        function _resolve(value) {
+            function once(fn) {
+                return function(result) {
+                    if (!state || state === "assumed") {
+                          fn(result);
+                    }
+                };
+            }
+            delete _this._parentCancel;
+            try {
+                var valueThen = value && (typeof value === "object" || typeof value === "function") && value.then;
+                if (typeof valueThen === "function") {
+                    if (value === _this) {
+                        _reject(new TypeError());
+                    } else {
+                        state = "assumed";
+                        var valueCancel = value && value.cancel;
+                        if (typeof valueCancel !== "function") {
+                            var deferred = new Deferred();
+                            value = deferred.promise;
+                            try {
+                                valueThen(deferred.resolve, deferred.reject, deferred.progress);
+                            } catch (thenError) {
+                                deferred.reject(thenError);
+                            }
+                            valueCancel = value.cancel;
+                            valueThen = value.then;
+                        }
+                        result = value;
+                        valueThen.call(value, once(_resolve), once(_reject));
+                        _this._parentCancel = valueCancel.bind(value);
+                    }
+                } else {
+                    state = "fulfilled";
+                    result = value;
+                    if (listeners.length) {
+                        enqueue(notify);
+                    }
+                }
+            } catch (error) {
+                once(_reject)(error);
+            }
+        }
+
+        function cancel() {
+            var parentCancel = _this._parentCancel;
+            if (parentCancel) {
+                delete _this._parentCancel;
+                parentCancel();
+            } else if (!state) {
+                var cancelError = new Error("Cancel");
+                cancelError.name = "Cancel";
+                _reject(cancelError);
+            }
+        }
+
+
+        /**
+         * Resolves this Deferred.
+         * @name resolve
+         * @function
+         * @memberOf orion.Deferred.prototype
+         * @param {Object} value
+         * @returns {orion.Promise}
+         */
+        this.resolve = function(value) {
+            if (!state) {
+                _resolve(value);
+            }
+            return _this;
+        };
+
+        /**
+         * Rejects this Deferred.
+         * @name reject
+         * @function
+         * @memberOf orion.Deferred.prototype
+         * @param {Object} error
+         * @param {Boolean} [strict]
+         * @returns {orion.Promise}
+         */
+        this.reject = function(error) {
+            if (!state) {
+                _reject(error);
+            }
+            return _this;
+        };
+
+        /**
+         * Notifies listeners of progress on this Deferred.
+         * @name progress
+         * @function
+         * @memberOf orion.Deferred.prototype
+         * @param {Object} update The progress update.
+         * @returns {orion.Promise}
+         */
+        this.progress = function(update) {
+            if (!state) {
+                listeners.forEach(function(listener) {
+                    if (listener.progress) {
+                        try {
+                            listener.progress(update);
+                        } catch (ignore) {
+                            // ignore
+                        }
+                    }
+                });
+            }
+            return _this.promise;
+        };
+
+        this.cancel = function() {
+            if (_this._parentCancel) {
+                setTimeout(cancel, 0);
+            } else {
+                cancel();
+            }
+            return _this;
+        };
+
+        // Note: "then" ALWAYS returns before having onResolve or onReject called as per http://promises-aplus.github.com/promises-spec/
+        this.then = function(onFulfill, onReject, onProgress) {
+        	var deferred = new Deferred();
+            deferred._parentCancel = _this.promise.cancel;
+            listeners.push({
+                resolve: onFulfill,
+                reject: onReject,
+                progress: onProgress,
+                deferred: deferred
+            });
+            if (state === "fulfilled" || state === "rejected") {
+                enqueue(notify);
+            }
+            return deferred.promise;
+        };
+
+        /**
+         * The promise exposed by this Deferred.
+         * @name promise
+         * @field
+         * @memberOf orion.Deferred.prototype
+         * @type orion.Promise
+         */
+        this.promise = {
+            then: _this.then,
+            cancel: _this.cancel
+        };
+    }
+
+    /**
+     * Returns a promise that represents the outcome of all the input promises.
+     * <p>When <code>all</code> is called with a single parameter, the returned promise has <dfn>eager</dfn> semantics,
+     * meaning that if any input promise rejects, the returned promise immediately rejects, without waiting for the rest of the
+     * input promises to fulfill.</p>
+     *
+     * To obtain <dfn>lazy</dfn> semantics (meaning the returned promise waits for every input promise to fulfill), pass the
+     * optional parameter <code>optOnError</code>.
+     * @name all
+     * @function
+     * @memberOf orion.Deferred
+     * @static
+     * @param {orion.Promise[]} promises The input promises.
+     * @param {Function} [optOnError] Handles a rejected input promise. <code>optOnError</code> is invoked for every rejected
+     * input promise, and is passed the reason the input promise was rejected. <p><code>optOnError</code> can return a value, which
+     * allows it to act as a transformer: the return value serves as the final fulfillment value of the rejected promise in the 
+     * results array generated by <code>all</code>.
+     * @returns {orion.Promise} A new promise. The returned promise is generally fulfilled to an <code>Array</code> whose elements
+     * give the fulfillment values of the input promises. <p>However, if an input promise rejects and eager semantics is used, the 
+     * returned promise will instead be fulfilled to a single error value.</p>
+     */
+    Deferred.all = function(promises, optOnError) {
+        var count = promises.length,
+            result = [],
+            rejected = false,
+            deferred = new Deferred();
+
+        deferred.then(undefined, function() {
+            rejected = true;
+            promises.forEach(function(promise) {
+                if (promise.cancel) {
+                    promise.cancel();
+                }
+            });
+        });
+
+        function onResolve(i, value) {
+            if (!rejected) {
+                result[i] = value;
+                if (--count === 0) {
+                    deferred.resolve(result);
+                }
+            }
+        }
+
+        function onReject(i, error) {
+            if (!rejected) {
+                if (optOnError) {
+                    try {
+                        onResolve(i, optOnError(error));
+                        return;
+                    } catch (e) {
+                        error = e;
+                    }
+                }
+                deferred.reject(error);
+            }
+        }
+
+        if (count === 0) {
+            deferred.resolve(result);
+        } else {
+            promises.forEach(function(promise, i) {
+                promise.then(onResolve.bind(undefined, i), onReject.bind(undefined, i));
+            });
+        }
+        return deferred.promise;
+    };
+
+    /**
+     * Applies callbacks to a promise or to a regular object.
+     * @name when
+     * @function
+     * @memberOf orion.Deferred
+     * @static
+     * @param {Object|orion.Promise} value Either a {@link orion.Promise}, or a normal value.
+     * @param {Function} onResolve Called when the <code>value</code> promise is resolved. If <code>value</code> is not a promise,
+     * this function is called immediately.
+     * @param {Function} onReject Called when the <code>value</code> promise is rejected. If <code>value</code> is not a promise, 
+     * this function is never called.
+     * @param {Function} onProgress Called when the <code>value</code> promise provides a progress update. If <code>value</code> is
+     * not a promise, this function is never called.
+     * @returns {orion.Promise} A new promise.
+     */
+    Deferred.when = function(value, onResolve, onReject, onProgress) {
+        var promise, deferred;
+        if (value && typeof value.then === "function") { //$NON-NLS-0$
+            promise = value;
+        } else {
+            deferred = new Deferred();
+            deferred.resolve(value);
+            promise = deferred.promise;
+        }
+        return promise.then(onResolve, onReject, onProgress);
+    };
+
+    return Deferred;
+}));

--- a/plugin.html
+++ b/plugin.html
@@ -5,9 +5,11 @@
     <title>
       Orion.Umple Plugin
     </title>
-    <script src="http://orionhub.org/orion/plugin.js"></script>
+    <script src="Deferred.js"></script>
+    <script src="plugin.js"></script>
     <script src="orion.umple.js"></script>
   </head>
   <body>
+    This webpage is intended to be plugged in to an instance of <a href="http://orionhub.org">Eclipse Orion</a>.
   </body>
 </html>

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,576 @@
+/*******************************************************************************
+ * @license
+ * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials are made 
+ * available under the terms of the Eclipse Public License v1.0 
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution 
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html). 
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/*eslint-env browser, amd, node*/
+/* eslint-disable missing-nls */
+(function(root, factory) { // UMD
+    if (typeof define === "function" && define.amd) {
+        define(["orion/Deferred", "orion/EventTarget"], factory);
+    } else if (typeof exports === "object") {
+        module.exports = factory(require("orion/Deferred"), require("orion/EventTarget"));
+    } else {
+        root.orion = root.orion || {};
+        root.orion.PluginProvider = factory(root.orion.Deferred, root.orion.EventTarget);
+    }
+}(this, function(Deferred, EventTarget) {
+
+    function _equal(obj1, obj2) {
+        var keys1 = Object.keys(obj1);
+        var keys2 = Object.keys(obj2);
+        if (keys1.length !== keys2.length) {
+            return false;
+        }
+        keys1.sort();
+        keys2.sort();
+        for (var i = 0, len = keys1.length; i < len; i++) {
+            var key = keys1[i];
+            if (key !== keys2[i]) {
+                return false;
+            }
+            var value1 = obj1[key],
+                value2 = obj2[key];
+            if (value1 === value2) {
+                continue;
+            }
+            if (JSON.stringify(value1) !== JSON.stringify(value2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function ObjectReference(objectId, methods) {
+        this.__objectId = objectId;
+        this.__methods = methods;
+    }
+    
+    function PluginProvider(headers, serviceRegistry) {
+        var _headers = headers;
+        var _connected = false;
+
+        var _currentMessageId = 0;
+        var _currentObjectId = 0;
+        var _currentServiceId = 0;
+
+        var _requestReferences = {};
+        var _responseReferences = {};
+        var _objectReferences = {};
+        var _serviceReferences = {};
+        
+        var _services;
+        var _remoteServices = {};
+        var _registry = serviceRegistry;
+        var _connectCallback;
+        
+        var _ports = [];
+        var _shared = false;
+        
+        var _target = null;
+        if (typeof(window) === "undefined") {
+            if (self.postMessage) {
+                _target = self;
+            } else {
+                _shared = true;
+            }
+        } else if (window !== window.parent) {
+            _target = window.parent;
+        } else if (window.opener !== null) {
+            _target = window.opener;
+        }        
+
+        function _publish(message, target) {
+            target = target || _target;
+            if (target) {
+                if (typeof(ArrayBuffer) === "undefined") {
+                    message = JSON.stringify(message);
+                }
+                if (target === self || _shared) {
+                    target.postMessage(message);
+                } else {
+                    target.postMessage(message, "*");
+                }
+            }
+        }
+        var _notify = _publish;
+        var _errHandler = function(evt){
+        	_publish({method: "error", error: _serializeError(evt.error)});
+        };
+        addEventListener("error", _errHandler);
+        
+        var lastHeartbeat;
+        var startTime = new Date().getTime();
+        function log(state) {
+            if (typeof(localStorage) !== "undefined" && localStorage.pluginLogging) {
+            	console.log(state + "(" + (new Date().getTime() - startTime) + "ms)=" + self.location);
+        	}
+        }
+        function heartbeat() {
+            var time = new Date().getTime();
+            // This timeout depends on the handshake timeout of the plugin registry. Update both accordingly.
+            if (lastHeartbeat  && time - lastHeartbeat < 4000) return;
+            lastHeartbeat = time;
+            _publish({
+                method: "loading"
+            });
+            log("heartbeat");
+        }
+        heartbeat();
+
+        if (_shared) {
+            self.addEventListener("connect", function(evt) {
+                var port = evt.ports[0];
+                _ports.push(port);
+                if (_connected) {
+                    var message = {
+                        method: "plugin",
+                        params: [_getPluginData()]
+                    };
+                    _publish(message, port);
+                } else {
+                    heartbeat();
+                }
+                port.addEventListener("message",  function(evt) {
+                	_handleMessage(evt, port);
+                });
+                port.start();
+            });
+        }
+
+        function _getPluginData() {
+            var services = [];
+            // we filter out the service implementation from the data
+            Object.keys(_serviceReferences).forEach(function(serviceId) {
+                var serviceReference = _serviceReferences[serviceId];
+                services.push({
+                    serviceId: serviceId,
+                    names: serviceReference.names,
+                    methods: serviceReference.methods,
+                    properties: serviceReference.properties
+                });
+            });
+            return {
+            	updateRegistry: !!_registry,
+                headers: _headers || {},
+                services: services
+            };
+        }
+
+        function _jsonXMLHttpRequestReplacer(name, value) {
+            if (value && value instanceof XMLHttpRequest) {
+                var status, statusText;
+                try {
+                    status = value.status;
+                    statusText = value.statusText;
+                } catch (e) {
+                    // https://bugs.webkit.org/show_bug.cgi?id=45994
+                    status = 0;
+                    statusText = ""; //$NON-NLS-0
+                }
+                return {
+                    status: status || 0,
+                    statusText: statusText
+                };
+            }
+            return value;
+        }
+
+        function _serializeError(error) {
+            var result = error ? JSON.parse(JSON.stringify(error, _jsonXMLHttpRequestReplacer)) : error; // sanitizing Error object
+            if (error instanceof Error) {
+                result.__isError = true;
+                result.message = result.message || error.message;
+                result.name = result.name || error.name;
+            }
+            return result;
+        }
+
+        function _request(message, target) {
+            target = target || _target;
+            if (!target) {
+                return new Deferred().reject(new Error("plugin not connected"));
+            }
+
+            message.id = String(_currentMessageId++);
+            var d = new Deferred();
+            _responseReferences[message.id] = d;
+            d.then(null, function(error) {
+                if (_connected && error instanceof Error && error.name === "Cancel") {
+                    _notify({
+                        requestId: message.id,
+                        method: "cancel",
+                        params: error.message ? [error.message] : []
+                    }, target);
+                }
+            });
+
+            var toStr = Object.prototype.toString;
+            message.params.forEach(function(param, i) {
+                if (toStr.call(param) === "[object Object]" && !(param instanceof ObjectReference)) {
+                    var candidate, methods;
+                    for (candidate in param) {
+                        if (toStr.call(param[candidate]) === "[object Function]") {
+                            methods = methods || [];
+                            methods.push(candidate);
+                        }
+                    }
+                    if (methods) {
+                        var objectId = _currentObjectId++;
+                        _objectReferences[objectId] = param;
+                        var removeReference = function() {
+                            delete _objectReferences[objectId];
+                        };
+                        d.then(removeReference, removeReference);
+                        message.params[i] = new ObjectReference(objectId, methods);
+                    }
+                }
+            });
+            _notify(message, target);
+            return d.promise;
+        }
+
+        function _throwError(messageId, error, target) {
+            if (messageId || messageId === 0) {
+                _notify({
+                    id: messageId,
+                    result: null,
+                    error: error
+                }, target);
+            } else {
+                console.log(error);
+            }
+        }
+
+        function _callMethod(messageId, implementation, method, params, target) {
+            params.forEach(function(param, i) {
+                if (param && typeof param.__objectId !== "undefined") {
+                    var obj = {};
+                    param.__methods.forEach(function(method) {
+                        obj[method] = function() {
+                            return _request({
+                                objectId: param.__objectId,
+                                method: method,
+                                params: Array.prototype.slice.call(arguments)
+                            }, target);
+                        };
+                    });
+                    params[i] = obj;
+                }
+            });
+            var response = typeof messageId === "undefined" ? null : {
+                id: messageId,
+                result: null,
+                error: null
+            };
+            try {
+                var promiseOrResult = method.apply(implementation, params);
+                if (!response) {
+                    return;
+                }
+
+                if (promiseOrResult && typeof promiseOrResult.then === "function") {
+                    _requestReferences[messageId] = promiseOrResult;
+                    promiseOrResult.then(function(result) {
+                        delete _requestReferences[messageId];
+                        response.result = result;
+                        _notify(response, target);
+                    }, function(error) {
+                        if (_requestReferences[messageId]) {
+                            delete _requestReferences[messageId];
+                            response.error = _serializeError(error);
+                            _notify(response, target);
+                        }
+                    }, function() {
+                        _notify({
+                            responseId: messageId,
+                            method: "progress",
+                            params: Array.prototype.slice.call(arguments)
+                        }, target);
+                    });
+                } else {
+                    response.result = promiseOrResult;
+                    _notify(response, target);
+                }
+            } catch (error) {
+                if (response) {
+                    response.error = _serializeError(error);
+                    _notify(response, target);
+                }
+            }
+        }
+
+        function _handleMessage(evnt, target) {
+            if (!_shared && evnt.source !== _target && typeof window !== "undefined") {
+                return;
+            }
+            var data = evnt.data;
+            var message = (typeof data !== "string" ? data : JSON.parse(data));
+            try {
+                if (message.method) { // request
+                    var method = message.method,
+                        params = message.params || [];
+                    if ("serviceId" in message) {
+                        var service = _serviceReferences[message.serviceId];
+                        if (!service) {
+                            _throwError(message.id, "service not found", target);
+                        } else {
+	                        service = service.implementation;
+	                        if (method in service) {
+	                            _callMethod(message.id, service, service[method], params, target);
+	                        } else {
+	                            _throwError(message.id, "method not found", target);
+	                        }
+                    	}
+                    } else if ("objectId" in message) {
+                        var object = _objectReferences[message.objectId];
+                        if (!object) {
+                            _throwError(message.id, "object not found", target);
+                        } else if (!method in object) {
+                            _callMethod(message.id, object, object[method], params, target);
+                        } else {
+                            _throwError(message.id, "method not found", target);
+                        }
+                    } else if ("requestId" in message) {
+                        var request = _requestReferences[message.requestId];
+                        if (request && method === "cancel" && request.cancel) {
+                            request.cancel.apply(request, params);
+                        }
+                    } else if ("responseId" in message) {
+                        var response = _responseReferences[message.responseId];
+                        if (response && method === "progress" && response.progress) {
+                            response.progress.apply(response, params);
+                        }
+                    } else {
+                        if ("plugin" === message.method) { //$NON-NLS-0$
+                            var manifest = message.params[0];
+                            _update({
+                                services: manifest.services
+                            });
+                        } else {
+                            throw new Error("Bad method: " + message.method);
+                        }
+                    }
+                } else if (message.id) {
+                    var deferred = _responseReferences[String(message.id)];
+                    if (deferred) {
+	                    delete _responseReferences[String(message.id)];
+	                    if (message.error) {
+	                        deferred.reject(message.error);
+	                    } else {
+	                        deferred.resolve(message.result);
+	                    }
+                    }
+                }
+            } catch (e) {
+                console.log("Plugin._messageHandler " + e);
+            }
+        }        
+        
+        function _createServiceProxy(service) {
+            var serviceProxy = {};
+            if (service.methods) {
+                service.methods.forEach(function(method) {
+                    serviceProxy[method] = function() {
+                        var message = {
+                            serviceId: service.serviceId,
+                            method: method,
+                            params: Array.prototype.slice.call(arguments)
+                        };
+                        return _request(message);
+                    };
+                });
+
+                if (serviceProxy.addEventListener && serviceProxy.removeEventListener && EventTarget) {
+                    var eventTarget = new EventTarget();
+                    var objectId = _currentObjectId++;
+                    _objectReferences[objectId] = {
+                        handleEvent: eventTarget.dispatchEvent.bind(eventTarget)
+                    };
+                    var listenerReference = new ObjectReference(objectId, ["handleEvent"]);
+
+                    var _addEventListener = serviceProxy.addEventListener;
+                    serviceProxy.addEventListener = function(type, listener) {
+                        if (!eventTarget._namedListeners[type]) {
+                            _addEventListener(type, listenerReference);
+                        }
+                        eventTarget.addEventListener(type, listener);
+                    };
+                    var _removeEventListener = serviceProxy.removeEventListener;
+                    serviceProxy.removeEventListener = function(type, listener) {
+                        eventTarget.removeEventListener(type, listener);
+                        if (!eventTarget._namedListeners[type]) {
+                            _removeEventListener(type, listenerReference);
+                        }
+                    };
+                }
+            }
+            return serviceProxy;
+        }
+
+        function _createServiceProperties(service) {
+            var properties = JSON.parse(JSON.stringify(service.properties));
+            var objectClass = service.names || service.type || [];
+            if (!Array.isArray(objectClass)) {
+                objectClass = [objectClass];
+            }
+            properties.objectClass = objectClass;
+            return properties;
+        }
+
+        function _registerService(service) {
+        	if (!_registry) return;
+            var serviceProxy = _createServiceProxy(service);
+            var properties = _createServiceProperties(service);
+            var registration = _registry.registerService(service.names || service.type, serviceProxy, properties);
+            _remoteServices[service.serviceId] = {
+                registration: registration,
+                proxy: serviceProxy
+            };
+        }
+
+        function _update(input) {
+            var oldServices = _services || [];
+            _services = input.services || [];
+
+            if (!_equal(_services, oldServices)) {
+	            var serviceIds = [];
+				_services.forEach(function(service) {
+					var serviceId = service.serviceId;
+	                serviceIds.push(serviceId);
+	                var remoteService = _remoteServices[serviceId];
+	                if (remoteService) {
+	                    if (_equal(service.methods, Object.keys(remoteService.proxy))) {
+	                        var properties = _createServiceProperties(service);
+	                        var reference = remoteService.registration.getReference();
+	                        var currentProperties = {};
+	                        reference.getPropertyKeys().forEach(function(_name) {
+	                            currentProperties[_name] = reference.getProperty(_name);
+	                        });
+	                        if (!_equal(properties, currentProperties)) {
+	                            remoteService.registration.setProperties(properties);
+	                        }
+	                        return;
+	                    }
+	                    remoteService.registration.unregister();
+	                    delete _remoteServices[serviceId];
+	                }
+	                _registerService(service);
+	            });
+	            Object.keys(_remoteServices).forEach(function(serviceId) {
+	                if (serviceIds.indexOf(serviceId) === -1) {
+	                    _remoteServices[serviceId].registration.unregister();
+	                    delete _remoteServices[serviceId];
+	                }
+	            });
+           }
+           
+           if (_connectCallback) {
+               _connectCallback();
+               _connectCallback = null;
+           }
+        }
+
+        this.updateHeaders = function(headers) {
+            if (_connected) {
+                throw new Error("Cannot update headers. Plugin Provider is connected");
+            }
+            _headers = headers;
+        };
+
+        this.registerService = function(names, implementation, properties) {
+            if (_connected) {
+                throw new Error("Cannot register service. Plugin Provider is connected");
+            }
+
+            if (typeof names === "string") {
+                names = [names];
+            } else if (!Array.isArray(names)) {
+                names = [];
+            }
+
+            var method = null;
+            var methods = [];
+            for (method in implementation) {
+                if (typeof implementation[method] === 'function') {
+                    methods.push(method);
+                }
+            }
+            _serviceReferences[_currentServiceId++] = {
+                names: names,
+                methods: methods,
+                implementation: implementation,
+                properties: properties || {},
+                listeners: {}
+            };
+            heartbeat();
+        };
+        this.registerServiceProvider = this.registerService;
+
+        this.connect = function(callback, errback) {
+            if (_connected) {
+                if (callback) {
+                    callback();
+                }
+                return;
+            }
+            removeEventListener("error", _errHandler);
+            var message = {
+                method: "plugin",
+                params: [_getPluginData()]
+            };
+            if (!_shared) {
+                if (!_target) {
+                    if (errback) {
+                        errback("No valid plugin target");
+                    }
+                    return;
+                }           
+                addEventListener("message", _handleMessage, false);
+                _publish(message);
+            }
+            if (typeof(window) !== "undefined") {
+            	var head = document.getElementsByTagName("head")[0] || document.documentElement;
+            	var title = head.getElementsByTagName("title")[0];
+            	if (!title) {
+	            	title = document.createElement("title");
+	            	title.textContent = _headers.name;
+	            	head.appendChild(title);
+	        	}
+        	}
+
+            _ports.forEach(function(port) {
+                _publish(message, port);
+            });
+            _connected = true;
+            if (_registry) {
+            	_connectCallback = callback;
+            } else {
+	            if (callback) {
+	                callback();
+	            }
+            }
+        };
+
+        this.disconnect = function() {
+            if (_connected) {
+                removeEventListener("message", _handleMessage);
+                _ports.forEach(function(port) {
+                    port.close();
+                });
+                _ports = null;
+                _target = null;
+                _connected = false;
+            }
+            // Note: re-connecting is not currently supported
+        };            
+    }
+    
+    return PluginProvider;
+}));


### PR DESCRIPTION
(DO NOT PULL!)

Compilation prototype is added. To use, click on "Compile Umple Model" in the {Tools} menu in Orion when an Umple model is open in the editor.

All output is done in the console as File I/O is limited in Orion when using the plugin architecture. However, the compiler connects to UmpleOnline without a hitch.

In a future commit, the compilation code will be added to a server-side SDK plugin. This will mean that compilation will unfortunately be a feature that each server must add on it's own.
