### PR TITLE
Add mostly complete compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,70 @@ This is a plugin to extend the [Orion] text editor to support features allowing 
 ## Current Features
 
 - Context-free highlighting of Umple and extra code
+- Generation of Umple code directly in the Orion editor (Partial - see below)
 
 ## Work-in-Progress Features
 
 - Context-sensitive highlight
-- Generation of Umple code directly in the Orion editor
 - Live generation of UML diagrams of Umple code
 - Links to edit code in Orion (a la JSFiddle)
 
-## Setup
+## User Plugin Setup
 
-To set up this plugin, you must first download and host `plugin.html` and `orion.umple.js` onto a web server that an instance of Orion can pull it from. In Orion itself (either local or [hosted][Orion]), go to {Settings > Plug-ins} and click the 'Install' button on the top right. Enter the URL for `plugin.html` (with `orion.umple.js` in the same directory) and it should install without any issues.
+To set up this plugin, you must first download and host `plugin.html` and `orion.umple.js` onto a web server that an instance of Orion can retrieve it from. In Orion itself (either local or [hosted][Orion]), go to {Settings > Plug-ins} and click the 'Install' button on the top right. Enter the URL for `plugin.html` (with `orion.umple.js` in the same directory) and it should install without any issues.
+
+Do note that this plugin will not allow compilation of code using any arbitrary instance of Orion. In order to compile code in Orion, it must be prebuilt with Umple compiler support.
+
+## Server Plugin Setup
+
+For server admins who would like Umple compilation built into their Orion server instance, the following instructions will add that functionality.
+
+### For those who want to add Umple to an unmodified server
+
+Clone the orion client:
+
+    git clone https://git.eclipse.org/r/orion/org.eclipse.orion.client.git
+
+Copy the Umple.Orion files into the cloned repo
+
+    cp -r umple.orion/org.eclipse.orion.client/* org.eclipse.orion.client/
+
+Clone and build the server repo (note: the Orion Client and Server repositories must be in the same directory for Orion to build.)
+
+    git clone https://git.eclipse.org/r/orion/org.eclipse.orion.server.git
+    cd org.eclipse.orion.server
+    mvn clean install -P platform-kepler,local-build -DskipTests
+
+The resulting binaries will be in a zip folder in the server repository.
+
+    cd org.eclipse.orion.server/releng/org.eclipse.orion.server.repository/target/products/
+
+Once there, the binaries will be in zipped files. Unzip the file containing the binaries for your target platform, then
+
+    cd eclipse
+    ./orion
+
+And Orion will run locally on port 8080. Additional configuration will be required with Apache and Nginx for things to work on a web server.
+
+### For those who want to add Umple to an modified server
+
+In your Orion client repository, add the line
+
+    "plugins/orion.umple.html": true,
+
+to `org.eclipse.orion.client/bundles/org.eclipse.orion.ui/web/defaults.pref` inside the `"/plugins":{ }` section. Additionally, add the line
+
+    { name : "plugins/orion.umple" }
+
+to `org.eclipse.orion.client/releng/org.eclipse.orion.releng/builder/scripts/orion.build.js` in the modules section (around line 120). Then, in the directory containing the client and Umple.Orion repositories:
+
+    cp umple.orion/org.eclipse.orion.client/bundles/org.eclipse.orion.ui/web/plugins/* org.eclipse.orion.client/bundles/org.eclipse.orion.ui/web/plugins/
+
+And then build the server as usual.
+
+## License
+
+See the Umple license for copying details.
 
 [Orion]: http://orionhub.org
 [Umple]: http://umple.org

--- a/org.eclipse.orion.client/bundles/org.eclipse.orion.client.ui/web/defaults.pref
+++ b/org.eclipse.orion.client/bundles/org.eclipse.orion.client.ui/web/defaults.pref
@@ -1,0 +1,13 @@
+{
+	"/plugins":{
+		"plugins/orionSharedWorker.js": true,
+		"plugins/orion.umple.html": true,
+		"git/plugins/gitPlugin.html":true,
+		"webtools/plugins/webToolsPlugin.html":true,
+		"javascript/plugins/javascriptPlugin.html":true,
+		"edit/content/imageViewerPlugin.html":true,
+		"edit/content/jsonEditorPlugin.html":true,
+		"cfui/plugins/cFPlugin.html":true,
+		"cfui/plugins/cFDeployPlugin.html":true
+	}
+}

--- a/org.eclipse.orion.client/bundles/org.eclipse.orion.client.ui/web/plugins/orion.umple.html
+++ b/org.eclipse.orion.client/bundles/org.eclipse.orion.client.ui/web/plugins/orion.umple.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script src="../requirejs/require.min.js"></script>
+    <script type="text/javascript">
+    /*eslint-env browser, amd*/
+    /* This first require allows the plugin to have proper scope. */
+    require({
+      baseUrl: '..'
+    });
+    require(["plugins/orion.umple"]);
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/org.eclipse.orion.client/bundles/org.eclipse.orion.client.ui/web/plugins/orion.umple.js
+++ b/org.eclipse.orion.client/bundles/org.eclipse.orion.client.ui/web/plugins/orion.umple.js
@@ -1,0 +1,144 @@
+require(["orion/Deferred", "orion/plugin"], function(Deferred, PluginProvider){
+  var provider = new PluginProvider({
+    name: "Orion.Umple",
+    version: "alpha",
+    description: "Umple (Model-Oriented Programming) support for Orion."
+  });
+
+  // Adds a new content type that recognizes Umple textual models
+  provider.registerService("orion.core.contenttype", {}, {
+    contentTypes: [
+      {
+        id: "text/umple",
+        name: "Textual Umple Model",
+        extension: [
+          "ump"
+        ],
+        // extends must be a string as it is otherwise reserved in Javascript
+        "extends": "text/plain"
+      }
+    ]
+  });
+
+  // Adds a grammar for highlighting code and keywords in Umple models
+  provider.registerService("orion.edit.highlighter", {}, {
+    id: "orion.umple.highlight",
+    contentTypes: ["text/umple"],
+    patterns: [
+      // Matcing braces and parenthesis from Orion's library
+      { include: "orion.lib#string_doubleQuote" },
+      { include: "orion.lib#string_singleQuote" },
+      { include: "orion.lib#brace_open" },
+      { include: "orion.lib#brace_close" },
+      { include: "orion.lib#bracket_open" },
+      { include: "orion.lib#bracket_close" },
+      { include: "orion.lib#parenthesis_open" },
+      { include: "orion.lib#parenthesis_close" },
+
+      // Numbers and c-style comments, which Umple uses.
+      { include: "orion.lib#number_decimal" },
+      { include: "orion.c-like#comments" },
+
+      // Umple keywords
+      {
+        name: "keyword.other.reserved",
+        match: "\\b(?:class|interface|namespace|external|generate|strictness|association|trait|depend|use|isA|lazy|immutable|const|settable|internal|autounique|defaulted|before|after|Integer|Float|String|Double|Boolean|Date|Time|->|--|entry|do|exit|singleton|trace|tracer)\\b"
+      },
+
+      // For extra code, straight import for now like in UmpleOnline.
+      { include: "orion.java" },
+      { include: "orion.cpp" },
+      { include: "orion.php" }
+      // There's no ruby at this time, unfortunately.
+    ]
+  });
+
+  // Registers a new compiler for each language
+  // Adding a new languate to the array should fully add another language to the compiler.
+  ["Java", "Php", "Cpp", "Ruby"].forEach(function(lang){
+    provider.registerService("orion.edit.command", {
+      run: function (selectedText, text, selection, fileName) {
+        var result = compileUmple(text, fileName.slice(0, fileName.lastIndexOf("/")), lang);
+        // TODO window.alert doesn't work due to the plugin being sandboxed. This will likely be patched in another version of Orion.
+        if (result == null) {
+          window.alert("Compilation Finished. Refresh the page to see the compiled files.");
+          console.log("Compilation Finished. Refresh the page to see the compiled files.");
+        } else {
+          window.alert("Compilation error: " + result);
+          console.log("Compilation error: " + result);
+        }
+      }
+    }, {
+      name: "Compile Umple Model ("+lang+")",
+      id: "orion.umple.compile."+lang.toLowerCase(),
+      tooltip: "Compile this Umple Model into "+ lang +" code using UmpleOnline.",
+      contentType: ["text/umple"]
+    });
+  });
+
+  // RESTFUL compiler using UmpleOnline
+  function compileUmple (modelText, targetDirectory, targetLang) {
+    compiler = new XMLHttpRequest();
+    compiler.open("POST", "http://cruise.eecs.uottawa.ca/umpleonline/scripts/compiler.php", true);
+    var data = new FormData();
+    data.append('language', targetLang);
+    data.append('languageStyle', 'java');
+    data.append('error', 'true');
+    data.append('umpleCode', modelText+"//$?[End_of_model]$?");
+    compiler.addEventListener("loadend", function () {
+      var compilerResponse = decodeHtml(this.responseText);
+      // Return an error if the compiler hasn't sent any files.
+      if (compilerResponse.indexOf("//%%") == -1) {
+        return compilerResponse;
+      }
+      do {
+        compilerResponse = compilerResponse.slice(compilerResponse.indexOf("//%%")+14);
+        filename = compilerResponse.slice(0, compilerResponse.indexOf(' ')) + getExt(targetLang);
+        // Create the new file.
+        var fileCreate = new XMLHttpRequest();
+        fileCreate.open("POST", targetDirectory);
+        fileCreate.addEventListener("loadend", function () {
+          // Write the file contents.
+          fileWrite = new XMLHttpRequest();
+          compilerResponse = compilerResponse.slice(compilerResponse.indexOf("\n")+1);
+          compilerResponse = compilerResponse.slice(compilerResponse.indexOf("\n")+1);
+          if (compilerResponse.indexOf("//%%") >= 0) {
+            fileContents = compilerResponse.slice(0, compilerResponse.indexOf("//%%"));
+          } else {
+            fileContents = compilerResponse;
+          }
+          fileWrite.open("PUT", targetDirectory+"/"+filename);
+          // Send the file contents.
+          fileWrite.send(fileContents);
+        });
+        // Send the file creation
+        fileCreate.send(filename);
+      } while (compilerResponse.indexOf("//%%") != -1);
+      return null;
+    });
+    // Send the model to UmpleOnline
+    compiler.send(data);
+
+    // Get the file extension for generated files
+    function getExt(lang){
+      switch (lang) {
+      case "Java" : return ".java";
+      case "Php"  : return ".php";
+      case "Cpp"  : return "";      // UmpleOnline takes care of C++ extensions.
+      case "Ruby" : return ".rb";
+      default     : return "";
+      }
+    }
+
+    // Turns the compiler's HTML escape codes into plaintext.
+    function decodeHtml(html) {
+      var txt = document.createElement("textarea");
+      txt.innerHTML = html;
+      return txt.value;
+    }
+  }
+
+  // Get connected to Orion so that services can actually be provided.
+  provider.connect();
+});
+

--- a/org.eclipse.orion.client/releng/org.eclipse.orion.client.releng/builder/scripts/orion.build.js
+++ b/org.eclipse.orion.client/releng/org.eclipse.orion.client.releng/builder/scripts/orion.build.js
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2013, 2015 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html).
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/* eslint-disable missing-nls */
+({
+    optimizeCss: "standard.keepLines",
+    optimize: "uglify2",
+    generateSourceMaps: true,
+    preserveLicenseComments: false,
+
+    pragmas: {
+        asynchLoader: true
+    },
+
+    skipDirOptimize: true,
+
+    baseUrl: '.',
+    locale: 'en-us',
+    inlineText: true,
+    paths: {
+        text: 'requirejs/text',
+        json: 'requirejs/json',
+        i18n: 'requirejs/i18n',
+        domReady: 'requirejs/domReady',
+        gcli: 'gcli/gcli',
+        util: 'gcli/util'
+    },
+    // Bundles whose ./web/ folders will be copied into the staging directory by the builder.
+    // ** For Nashorn compatibility, use single quotes here **
+    bundles: [
+        '${orionClient}/bundles/org.eclipse.orion.client.core',
+        '${orionClient}/bundles/org.eclipse.orion.client.cf',
+        '${orionClient}/bundles/org.eclipse.orion.client.ui',
+        '${orionClient}/bundles/org.eclipse.orion.client.editor',
+        '${orionClient}/bundles/org.eclipse.orion.client.git',
+        '${orionClient}/bundles/org.eclipse.orion.client.help',
+        '${orionClient}/bundles/org.eclipse.orion.client.javascript',
+        '${orionClient}/bundles/org.eclipse.orion.client.webtools',
+        '${orionClient}/bundles/org.eclipse.orion.client.users'
+    ],
+    // Folders that should be searched for JSDoc
+    jsdocs: [
+        '${orionClient}/bundles/org.eclipse.orion.client.core/web/orion/',
+        '${orionClient}/bundles/org.eclipse.orion.client.cf/web/orion/',
+        '${orionClient}/bundles/org.eclipse.orion.client.ui/web/orion/',
+        '${orionClient}/bundles/org.eclipse.orion.client.editor/web/orion/',
+        '${orionClient}/bundles/org.eclipse.orion.client.git/web/orion/',
+        '${orionClient}/bundles/org.eclipse.orion.client.javascript/web/javascript/',
+        '${orionClient}/bundles/org.eclipse.orion.client.webtools/web/webtools/',
+        '${orionClient}/bundles/org.eclipse.orion.client.users/web/orion/'
+    ],
+    // List of modules that r.js will optimize
+    modules: (function() {
+        var modules = [
+            { name: "index" },
+            { name: "cfui/apps" },
+            { name: "cfui/logs" },
+            { name: "cfui/plugins/cFDeployPlugin" },
+            { name: "cfui/plugins/cFDeployService" },
+            { name: "cfui/plugins/cFPlugin" },
+            { name: "cfui/plugins/wizards/generic/genericDeploymentWizard" },
+            { name: "compare/compare" },
+            { name: "edit/content/imageViewerPlugin" },
+            { name: "edit/content/jsonEditorPlugin" },
+            { name: "edit/edit" },
+            { name: "git/git-repository" },
+            { name: "git/plugins/gitPlugin" },
+            { name: "help/help" },
+            { name: "javascript/plugins/javascriptPlugin" },
+            { name: "javascript/plugins/ternWorkerCore" },
+            { name: "mixloginstatic/javascript/landing-new" },
+            { name: "mixloginstatic/javascript/login" },
+            { name: "mixloginstatic/javascript/register" },
+            { name: "mixloginstatic/javascript/reset" },
+            { name: "mixloginstatic/javascript/ServerStatus" },
+            { name: "mixloginstatic/javascript/manageExternalIds" },
+            { name: "operations/list" },
+            { name: "plugins/orionPlugin" },
+            { name: "plugins/GerritFilePlugin" },
+            { name: "plugins/GitHubFilePlugin" },
+            { name: "plugins/authenticationPlugin" },
+            { name: "plugins/fileClientPlugin" },
+            { name: "plugins/helpPlugin" },
+            { name: "plugins/jslintPlugin" },
+            { name: "plugins/languageToolsPlugin" },
+            { name: "plugins/languages/arduino/arduinoPlugin" },
+            { name: "plugins/languages/c/cPlugin" },
+            { name: "plugins/languages/cpp/cppPlugin" },
+            { name: "plugins/languages/docker/dockerPlugin" },
+            { name: "plugins/languages/erlang/erlangPlugin" },
+            { name: "plugins/languages/go/goPlugin" },
+            { name: "plugins/languages/haml/hamlPlugin" },
+            { name: "plugins/languages/java/javaPlugin" },
+            { name: "plugins/languages/less/lessPlugin" },
+            { name: "plugins/languages/lua/luaPlugin" },
+            { name: "plugins/languages/markdown/markdownPlugin" },
+            { name: "plugins/languages/objectiveC/objectiveCPlugin" },
+            { name: "plugins/languages/php/phpPlugin" },
+            { name: "plugins/languages/python/pythonPlugin" },
+            { name: "plugins/languages/ruby/rubyPlugin" },
+            { name: "plugins/languages/scss/scssPlugin" },
+            { name: "plugins/languages/sql/sqlPlugin" },
+            { name: "plugins/languages/swift/swiftPlugin" },
+            { name: "plugins/languages/typescript/typescriptPlugin" },
+            { name: "plugins/languages/xml/xmlPlugin" },
+            { name: "plugins/languages/xquery/xqueryPlugin" },
+            { name: "plugins/languages/yaml/yamlPlugin" },
+            { name: "plugins/googleAnalyticsPlugin" },
+            { name: "plugins/pageLinksPlugin" },
+            { name: "plugins/preferencesPlugin" },
+            { name: "plugins/site/sitePlugin" },
+            { name: "plugins/taskPlugin" },
+            { name: "plugins/webEditingPlugin" },
+            { name: "plugins/orion.umple" },
+            { name: "profile/user-list" },
+            { name: "profile/userservicePlugin" },
+            { name: "settings/settings" },
+            { name: "shell/plugins/shellPagePlugin" },
+            { name: "shell/shellPage" },
+            { name: "sites/site" },
+            { name: "sites/sites" },
+            { name: "sites/view" },
+            { name: "webtools/plugins/webToolsPlugin" },
+            { name: "orion/splash" },
+        ];
+        modules.forEach(function(module) {
+            module.excludeShallow = ["chai/chai"];
+        });
+        return modules;
+    }())
+});


### PR DESCRIPTION
As stated in the commit: "Compilation is added and works - save for one slight problem. The compiler does not output to the user. Orion has blocked alerts coming from sandboxed plugins, and the other method to show output to the user breaks XMLHttpRequests which compilation relies on."

To see output from the compiler, open a developer console (F12). The user will need to refresh the page to see the resulting files.

Consider this my final pull for now. I'll be mostly unable to contribute until the end of my exam period (April 8th), but after that I'll be able to continue with fixing the bug. In the mean time, I will provide small write-ups on each issue outlining what must be done for those.
